### PR TITLE
Fix error 40112 due to Duo API change

### DIFF
--- a/duo.py
+++ b/duo.py
@@ -19,6 +19,7 @@ import json
 import os
 import pyotp
 import requests
+from Crypto.PublicKey import RSA
 from docopt import docopt
 from os.path import dirname, join, abspath, isfile
 from urllib import parse
@@ -77,7 +78,11 @@ def activate_device(activation_url):
     #     {'response': {'hotp_secret': 'blahblah123', ...}, 'stat': 'OK'}
     # --- Expected Error:
     #     {'code': 40403, 'message': 'Unknown activation code', 'stat': 'FAIL'}
-    response = requests.post(activation_url)
+    params = {"pkpush": "rsa-sha512",
+              "pubkey": RSA.generate(2048).public_key().export_key("PEM").decode(),
+              "manufacturer": "Apple",
+              "model": "iPhone 4S"}
+    response = requests.post(activation_url, params=params)
     response_dict = json.loads(response.text)
     if response_dict["stat"] == "FAIL":
         raise Exception("Activation failed! Try a new QR/Activation URL")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyotp
 docopt
 requests
+pycryptodome


### PR DESCRIPTION
In June 2023 (might be earlier) Duo updated their internal API. Now registering a device requires specifying a signature method and a public key. This is implemented along with a requirement to sign subsequent login approvals sent from the Duo app.
While this sounds irrelevant to HOTP-based authentication, Duo won't let you register a new device without providing these parameters. This PR adds the required parameters.
`manufacturer` and `model` are added just for fun.